### PR TITLE
Fix the 'expect is not defined' error when running tests

### DIFF
--- a/test/index.js
+++ b/test/index.js
@@ -1,5 +1,7 @@
 var parse = require('../index.js');
-var assert = require('chai').assert
+var chai = require('chai');
+var assert = chai.assert;
+var expect = chai.expect;
 
 function pathsEqual(leftPath, rightPath) {
     assert.equal(JSON.stringify(leftPath), JSON.stringify(rightPath));


### PR DESCRIPTION
Simple fix for the "ReferenceError: expect is not defined" thrown when running the tests.